### PR TITLE
add Segment integration and pageview tracking

### DIFF
--- a/client/analytics/snippets.js
+++ b/client/analytics/snippets.js
@@ -1,0 +1,100 @@
+/* eslint-disable */
+
+/**
+ * Segment.com (Analytics.js)
+ */
+const segmentKey = Meteor.settings.public.segment.writeKey;
+
+if (segmentKey) {
+  // Create a queue, but don't obliterate an existing one!
+  analytics = window.analytics = window.analytics || [];
+
+  // If the real analytics.js is already on the page return.
+  if (analytics.initialize) return;
+
+  // If the snippet was invoked already show an error.
+  if (analytics.invoked) {
+    if (window.console && console.error) {
+      console.error('Segment snippet included twice.');
+    }
+    return;
+  }
+
+  // Invoked flag, to make sure the snippet
+  // is never invoked twice.
+  analytics.invoked = true;
+
+  // A list of the methods in Analytics.js to stub.
+  analytics.methods = [
+    'trackSubmit',
+    'trackClick',
+    'trackLink',
+    'trackForm',
+    'pageview',
+    'identify',
+    'reset',
+    'group',
+    'track',
+    'ready',
+    'alias',
+    'page',
+    'once',
+    'off',
+    'on'
+  ];
+
+  // Define a factory to create stubs. These are placeholders
+  // for methods in Analytics.js so that you never have to wait
+  // for it to load to actually record data. The `method` is
+  // stored as the first argument, so we can replay the data.
+  analytics.factory = function(method) {
+    return function() {
+      var args = Array.prototype.slice.call(arguments);
+      args.unshift(method);
+      analytics.push(args);
+      return analytics;
+    };
+  };
+
+  // For each of our methods, generate a queueing stub.
+  for (var i = 0; i < analytics.methods.length; i++) {
+    var key = analytics.methods[i];
+    analytics[key] = analytics.factory(key);
+  }
+
+  // Define a method to load Analytics.js from our CDN,
+  // and that will be sure to only ever load it once.
+  analytics.load = function(key) {
+    // Create an async script element based on your key.
+    var script = document.createElement('script');
+    script.type = 'text/javascript';
+    script.async = true;
+    script.src = ('https:' === document.location.protocol ? 'https://' : 'http://') + 'cdn.segment.com/analytics.js/v1/' + key + '/analytics.min.js';
+
+    // Insert our script next to the first script element.
+    var first = document.getElementsByTagName('script')[0];
+    first.parentNode.insertBefore(script, first);
+  };
+
+  // Add a version to keep track of what's in the wild.
+  analytics.SNIPPET_VERSION = '3.1.0';
+
+  // Load Analytics.js with your key, which will automatically
+  // load the tools you've enabled for your account. Boosh!
+  analytics.load(segmentKey);
+}
+
+
+/**
+ * Google Analytics
+ */
+if (Meteor.settings.public.ga.account) {
+  (function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,"script","//www.google-analytics.com/analytics.js","ga");
+
+  ga("create", Meteor.settings.public.ga.account, "auto");
+}
+
+/* eslint-enable */

--- a/common/main.jsx
+++ b/common/main.jsx
@@ -14,8 +14,21 @@ const AppRoutes = (
 ReactRouterSSR.Run(AppRoutes, {
   props: {
     onUpdate() {
-      // Notify the page has been changed to Google Analytics
-      ga("send", "pageview");
+      if (analytics) {
+        // Segment.com pageview
+        // TODO: figure out the best way to make this wait for the
+        // page title and location details to be ready
+        analytics.page({
+          path: window.location.pathname,
+          url: window.location.href,
+          title: Meteor.settings.public.redoc.title
+        });
+      }
+
+      if (ga) {
+        // Google Analytics pageview
+        ga("send", "pageview");
+      }
     }
   }
 }, {
@@ -23,18 +36,3 @@ ReactRouterSSR.Run(AppRoutes, {
     ReactCookie.plugToRequest(req, res);
   }
 });
-
-if (Meteor.isClient) {
-  if (Meteor.settings.public.ga.account !== undefined) {
-    // Load Google Analytics
-    /* eslint-disable */
-    (function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,"script","//www.google-analytics.com/analytics.js","ga");
-    /* eslint-enable */
-
-    ga("create", Meteor.settings.public.ga.account, "auto");
-    ga("send", "pageview");
-  }
-}

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,8 @@
 {
   "public": {
+    "segment": {
+      "writeKey": ""
+    },
     "ga": {
       "account": ""
     },


### PR DESCRIPTION
This is all working, but we still need to work out the fact that pageview calls to Segment and GA are happening before the page has finished rendering.  This means the page title and some items in `window.location` aren't available yet (all of which analytics libs use to automatically track page details).

For now, the details are manually passed into the Segment pageview calls, but the page title will always be equivalent to `Meteor.settings.public.redoc.title`.  I tried running that code in a bunch of different places, but the `onUpdate()` callback was the only place that reliably ran on every route.  So maybe someone more familiar with React Router than me can take a look and see about fixing that timing stuff.

For now, at least Segment works!  :)