### PR TITLE
Load params from default toc

### DIFF
--- a/common/docs/docs.jsx
+++ b/common/docs/docs.jsx
@@ -46,9 +46,20 @@ export default DocView = React.createClass({
         }
       });
 
+      // If no params have been given, load params from default TOC
+      let params = this.props.params;
+      if (Object.keys(params).length === 0) {
+        let defaultToc = ReDoc.Collections.TOC.findOne({ default: true });
+        if (!!defaultToc) {
+          params.repo = defaultToc.repo;
+          params.branch = defaultToc.branch;
+          params.alias = defaultToc.alias;
+        }
+      }
+
       return {
         docIsLoaded: sub.ready(),
-        currentDoc: ReDoc.Collections.Docs.findOne(this.props.params),
+        currentDoc: ReDoc.Collections.Docs.findOne(params),
         search: search
       };
     }

--- a/packages/redoc-core/server/publications.js
+++ b/packages/redoc-core/server/publications.js
@@ -28,12 +28,12 @@ Meteor.publish("CacheDocs", function (params) {
 
   // if we have no params, we're the root document
   if (Object.keys(params).length === 0) {
-    defaultDoc = ReDoc.Collections.TOC.findOne({
+    defaultToc = ReDoc.Collections.TOC.findOne({
       default: true
     });
-    params.repo = defaultDoc.repo;
+    params.repo = defaultToc.repo;
     params.branch = Meteor.settings.public.redoc.branch || "master";
-    params.alias = defaultDoc.alias;
+    params.alias = defaultToc.alias;
   }
   // get repo details
   let docRepo = ReDoc.Collections.Repos.findOne({


### PR DESCRIPTION
In docs.jsx, load default params from default TOC, if undefined, just like in CacheDocs publication.