### PR TITLE
Fix loading TOC from first branch

### DIFF
--- a/packages/redoc-core/server/methods.js
+++ b/packages/redoc-core/server/methods.js
@@ -219,11 +219,12 @@ Meteor.methods({
   "redoc/getDocSet": function (repo, fetchBranch) {
     check(repo, String);
     check(fetchBranch, Match.Optional(String, null));
-    const branch = fetchBranch || "development";
     // get repo details
     const docRepo = ReDoc.Collections.Repos.findOne({
       repo: repo
     });
+
+    const branch = fetchBranch || Meteor.settings.public.redoc.branch || docRepo.defaultBranch || "master";
 
     // we need to have a repo
     if (!docRepo) {


### PR DESCRIPTION
This fixes loading TOC from the branch specified in settings.json. If unspecified, load from repo's default branch.