### PR TITLE
Load toc from repository

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -30,6 +30,7 @@ ongoworks:spiderable
 #kadira:blaze-layout
 #kadira:react-layout
 
+underscorestring:underscore.string
 reactrouter:react-router-ssr
 meteorhacks:search-source
 fortawesome:fontawesome

--- a/.meteor/packages
+++ b/.meteor/packages
@@ -46,3 +46,4 @@ aldeed:collection2
 ongoworks:security
 standard-minifier-css
 standard-minifier-js
+nimble:restivus

--- a/.meteor/packages
+++ b/.meteor/packages
@@ -30,7 +30,6 @@ ongoworks:spiderable
 #kadira:blaze-layout
 #kadira:react-layout
 
-underscorestring:underscore.string
 reactrouter:react-router-ssr
 meteorhacks:search-source
 fortawesome:fontawesome

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -1,4 +1,5 @@
 accounts-base@1.2.4-rc.4
+accounts-password@1.1.6-rc.4
 aldeed:collection2@2.9.0
 aldeed:collection2-core@1.1.0
 aldeed:schema-deny@1.0.1
@@ -20,6 +21,7 @@ caching-html-compiler@1.0.4-rc.4
 callback-hook@1.0.6-rc.4
 check@1.1.2-rc.4
 chuangbo:cookie@1.1.0
+coffeescript@1.0.15-rc.4
 ddp@1.2.3-rc.4
 ddp-client@1.2.3-rc.4
 ddp-common@1.2.3-rc.4
@@ -30,6 +32,7 @@ diff-sequence@1.0.3-rc.4
 ecmascript@0.4.1-rc.4
 ecmascript-runtime@0.2.8-rc.4
 ejson@1.0.9-rc.4
+email@1.0.10-rc.4
 es5-shim@4.5.8-rc.4
 fastclick@1.0.9-rc.4
 fortawesome:fontawesome@4.5.0
@@ -62,6 +65,8 @@ modules@0.5.1-rc.4
 modules-runtime@0.6.1-rc.4
 mongo@1.1.5-rc.4
 mongo-id@1.0.2-rc.4
+nimble:restivus@0.8.9
+npm-bcrypt@0.7.8_2
 npm-mongo@1.4.41-rc.4
 observe-sequence@1.0.9-rc.4
 ongoworks:security@1.3.0
@@ -85,8 +90,11 @@ retry@1.0.5-rc.4
 routepolicy@1.0.8-rc.4
 service-configuration@1.0.7-rc.4
 session@1.1.3-rc.4
+sha@1.0.5-rc.4
+simple:json-routes@2.1.0
 spacebars@1.0.9-rc.4
 spacebars-compiler@1.0.9-rc.4
+srp@1.0.6-rc.4
 standard-minifier-css@1.0.4-rc.4
 standard-minifier-js@1.0.4-rc.4
 templating@1.1.7-rc.4

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -94,6 +94,7 @@ templating-tools@1.0.2-rc.4
 tracker@1.0.11-rc.4
 ui@1.0.9-rc.4
 underscore@1.0.6-rc.4
+underscorestring:underscore.string@3.3.4
 url@1.0.7-rc.4
 webapp@1.2.6-rc.4
 webapp-hashing@1.0.7-rc.4

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -94,7 +94,6 @@ templating-tools@1.0.2-rc.4
 tracker@1.0.11-rc.4
 ui@1.0.9-rc.4
 underscore@1.0.6-rc.4
-underscorestring:underscore.string@3.3.4
 url@1.0.7-rc.4
 webapp@1.2.6-rc.4
 webapp-hashing@1.0.7-rc.4

--- a/common/docs/toc.jsx
+++ b/common/docs/toc.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import classnames from "classnames";
 import "underscore";
+import s from "underscore.string";
 
 export default DocView = React.createClass({
   mixins: [ReactMeteorData],

--- a/common/docs/toc.jsx
+++ b/common/docs/toc.jsx
@@ -57,15 +57,21 @@ export default DocView = React.createClass({
     return links;
   },
 
-  renderMenu() {
-    const items = this.data.docs.map((item) => {
+  renderMenu(parentPath) {
+    let items = [];
+    let parentItems = _.filter(this.data.docs, function(item) { return item.parentPath === parentPath });
+    if (parentItems.length === 0) {
+      return [];
+    }
+
+    for (let item of parentItems) {
       const branch = this.props.params.branch || Meteor.settings.public.redoc.branch || "master";
       const url = `/${item.repo}/${branch}/${item.alias}`;
 
       let subList;
 
       if (item.documentTOC) {
-        const subItems = item.documentTOC.map((subItem, index) => {
+        subItems = item.documentTOC.map((subItem, index) => {
           const hashUrl = `${url}#${subItem.slug}`;
 
           return (
@@ -86,14 +92,16 @@ export default DocView = React.createClass({
         );
       }
 
-      return (
-        <li className={item.class} key={`${branch}-${item._id}`}>
+      const className = item.class || (parentPath ? 'guide-sub-nav-item' : 'guide-nav-item');
+      items.push (
+        <li className={className} key={`${branch}-${item._id}`}>
           <a href={url} onClick={this.handleDocNavigation}>{item.label}</a>
-
           {subList}
         </li>
       );
-    });
+      let currentPath = s.strLeftBack(item.docPath, '/README.md'); // Dirs path has /README.md attached to them
+      items = items.concat(this.renderMenu(currentPath));
+    }
 
     return items;
   },

--- a/package.json
+++ b/package.json
@@ -24,10 +24,11 @@
     "react": "^0.14.7",
     "react-cookie": "^0.4.3",
     "react-dom": "^0.14.7",
+    "react-helmet": "^2.3.1",
     "react-lazy-load": "^2.0.2",
     "react-router": "2.0.1",
     "react-select": "^1.0.0-beta8",
-    "react-helmet": "^2.3.1",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "underscore.string": "^3.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-lazy-load": "^2.0.2",
     "react-router": "2.0.1",
     "react-select": "^1.0.0-beta8",
+    "sha1": "^1.1.1",
     "underscore": "^1.8.3",
     "underscore.string": "^3.3.4"
   }

--- a/packages/redoc-base-theme/styles/docs.less
+++ b/packages/redoc-base-theme/styles/docs.less
@@ -41,6 +41,12 @@
   font-weight: 400;
 }
 
+.guide-sub-subnav-item.level-4 {
+  padding-left: 60px;
+  font-size: 11px;
+  font-weight: 400;
+}
+
 @media screen and (max-width: @screen-xs-max) {
   .redoc.docs .navigation {
     display: none;

--- a/packages/redoc-core/lib/schemas.js
+++ b/packages/redoc-core/lib/schemas.js
@@ -48,6 +48,10 @@ ReDoc.Schemas.Repos = new SimpleSchema({
   defaultBranch: {
     type: String,
     optional: true
+  },
+  contentsUrl: {
+    type: String,
+    optional: true
   }
 });
 
@@ -71,7 +75,8 @@ ReDoc.Schemas.DocumentTOC = new SimpleSchema({
 ReDoc.Schemas.TOC = new SimpleSchema({
   class: {
     type: String,
-    max: 60
+    max: 60,
+    optional: true
   },
   position: {
     type: Number,
@@ -88,6 +93,10 @@ ReDoc.Schemas.TOC = new SimpleSchema({
   },
   repo: {
     type: String
+  },
+  parentPath: {
+    type: String,
+    optional: true
   },
   documentTOC: {
     type: [ReDoc.Schemas.DocumentTOC],

--- a/packages/redoc-core/package.js
+++ b/packages/redoc-core/package.js
@@ -14,6 +14,7 @@ Package.onUse(function (api) {
   api.use("aldeed:simple-schema");
   api.use("percolate:synced-cron");
   api.use("mongo");
+  api.use("url");
 
   // add default initRepoData
   api.addAssets("private/redoc.json", "server");
@@ -25,6 +26,7 @@ Package.onUse(function (api) {
   // server
   api.addFiles("server/methods.js", "server");
   api.addFiles("server/publications.js", "server");
+  api.addFiles("server/restivus.js", "server");
   api.addFiles("server/startup.js", "server");
   // client
   api.addFiles("client/subscriptions.js", "client");

--- a/packages/redoc-core/server/methods.js
+++ b/packages/redoc-core/server/methods.js
@@ -3,6 +3,7 @@
 import "highlight.js";
 import punycode from "punycode";
 import "underscore";
+import s from "underscore.string";
 import TOCParser from "../lib/plugins/toc";
 
 export let hljs = require("highlight.js");

--- a/packages/redoc-core/server/methods.js
+++ b/packages/redoc-core/server/methods.js
@@ -199,7 +199,8 @@ Meteor.methods({
                 rawUrl: rawUrl,
                 release: releaseData.data,
                 branches: branchesData.data,
-                defaultBranch: repoData.data.default_branch
+                defaultBranch: repoData.data.default_branch,
+                contentsUrl: repoData.data.contents_url
               }
             });
           }
@@ -275,5 +276,96 @@ Meteor.methods({
         }
       });
     }
+  }
+
+/**
+ *  redoc/getRepoTOC
+ *  fetch all docs for a specified repo / branch starting at path
+ *  @param {String} repo - repo
+ *  @param {String} fetchBranch - optional branch
+ *  @param {String} path - optional path
+ *  @returns {undefined} returns
+ */
+  "redoc/getRepoTOC": function (repo, fetchBranch, path) {
+    this.unblock();
+    check(repo, String);
+    check(fetchBranch,  Match.Optional(String, null));
+    check(path,  Match.Optional(String, null));
+
+    // get repo details
+    const docRepo = ReDoc.Collections.Repos.findOne({
+      repo: repo
+    });
+
+    // we need to have a repo
+    if (!docRepo) {
+      console.log(`redoc/getRepoTOC: Failed to load repo data for ${repo}`);
+      return false;
+    }
+
+    let branch;
+    if (fetchBranch) {
+      branch = fetchBranch;
+    } else if (docRepo.branches && docRepo.branches.length > 0) {
+      for (let branch of docRepo.branches) {
+        Meteor.call("redoc/getRepoTOC", repo, branch.name, path);
+      }
+    } else {
+      branch = docRepo.defaultBranch || "master";
+    }
+
+    if (branch) {
+
+      // assemble TOC
+      let requestUrl = docRepo.contentsUrl.replace("{+path}", path ? encodeURIComponent(path) : "") + authString + '&ref=' + branch;
+      let contentData = Meteor.http.get(requestUrl, {
+        headers: {
+          "User-Agent": "ReDoc/1.0"
+        }
+      });
+
+      if (contentData && contentData.data) {
+        for (let sortIndex in contentData.data) {
+          let tocItem = contentData.data[sortIndex];
+
+          if (tocItem.type === 'file' && tocItem.path !== "README.md" && (tocItem.name.indexOf('.md') === -1 || tocItem.name === "README.md")) {
+            continue;
+          }
+
+          let matches, sort;
+          if (matches = tocItem.name.match(/^(\d+)/)) {
+            sort = s.toNumber(matches[1]);
+          } else {
+            sort = parseInt(sortIndex);
+          }
+          let tocData = {
+            alias: s.slugify(s.strLeftBack(tocItem.path, '.md').replace(/^(\d+)[ \.]+/, '')),
+            label: s.strLeftBack(tocItem.name, '.md').replace(/^(\d+)[ \.]+/, ''),
+            repo: repo,
+            branch: branch,
+            position: sort,
+            docPath: encodeURIComponent(tocItem.path)
+          };
+          // First README.md, on root
+          if (tocItem.path === "README.md") {
+            tocData.alias = 'welcome';
+            tocData.label = 'Welcome';
+            tocData.position = 0;
+            tocData.default = true;
+          }
+          if (path) {
+            tocData.parentPath = encodeURIComponent(path);
+          }
+          if (tocItem.type === 'dir') {
+            tocData.docPath += '/README.md';
+          }
+          ReDoc.Collections.TOC.insert(tocData);
+          if (tocItem.type === 'dir') {
+            Meteor.call("redoc/getRepoTOC", repo, branch, tocItem.path);
+          }
+        }
+      }
+    }
+    Meteor.call("redoc/getRepoData");
   }
 });

--- a/packages/redoc-core/server/methods.js
+++ b/packages/redoc-core/server/methods.js
@@ -114,10 +114,10 @@ Meteor.methods({
           position: index
         });
       });
-
-      // Run once will get all repo data for current repos
-      Meteor.call("redoc/getRepoData");
     }
+
+    // Run once will get all repo data for current repos
+    Meteor.call("redoc/getRepoData");
 
     // If TOC is still empty, get TOC from Repository
     if (ReDoc.Collections.TOC.find().count() === 0) {
@@ -249,6 +249,18 @@ Meteor.methods({
           // if TOC has different alias, we'll use that
           if (tocItem.alias) {
             docSet.alias = tocItem.alias;
+          }
+
+           // if TOC has different label, we'll use that
+          if (tocItem.label) {
+            let label = tocItem.label;
+            if (tocItem.parentPath) {
+              parent = ReDoc.Collections.TOC.findOne({ docPath: tocItem.parentPath + "/README.md" });
+              if (parent) {
+                label = parent.label + " - " + label;
+              }
+            }
+            docSet.label = label;
           }
 
           // pre-process documentation

--- a/packages/redoc-core/server/restivus.js
+++ b/packages/redoc-core/server/restivus.js
@@ -1,0 +1,30 @@
+import url from "url";
+import s from "underscore.string";
+import sha1 from 'sha1';
+
+Meteor.startup(function() {
+	if (Meteor.settings.services) {
+		serviceSettings = _.find(Meteor.settings.services, (service) => { return service['github'] });
+		if (serviceSettings && serviceSettings['github']) {
+			const settings = serviceSettings['github'];
+			if (settings.webhook && settings.webhook.updateDocs) {
+				let basename = s.rtrim(url.parse(__meteor_runtime_config__.ROOT_URL).pathname, '/');
+
+				let Api = new Restivus({
+					apiPath: basename + '/api'
+				});
+
+				Api.addRoute('updateDocs', { authRequired: false }, {
+					post: function() {
+						if (this.request && this.request.headers && this.request.headers['x-hub-signature'] === "sha1=" + sha1(JSON.stringify(this.bodyParams), settings.webhook.updateDocs).toString()) {
+							Meteor.call('redoc/flushDocCache');
+							return { success: true };
+						} else {
+							return { success: false };
+						}
+					}
+				});
+			}
+		}
+	}
+});

--- a/settings.json
+++ b/settings.json
@@ -38,7 +38,10 @@
   "services": [{
     "github": {
       "clientId": "",
-      "secret": ""
+      "secret": "",
+      "webhook": {
+        "updateDocs": ""
+      }
     }
   }],
   "redoc": {


### PR DESCRIPTION
With this PR, Redoc will fetch the TOC from the repository folders and files structure when tocData doesn't exist, i.e., remove the `tocData` section from the `private/redoc.json` or the `initialRepoData`. Ex.: 
```
{
  "repos": [{
    "org": "RocketChat",
    "repo": "Rocket.Chat.Docs",
    "label": "Rocket.Chat Docs",
    "description": "Rocket.Chat Documentation"
  }]
}
```

The Redoc will mirror GitHub structure. Each folder becomes a main nav item. Each .md file becomes a sub-nav item. If the folder contains a README.md, this becomes the content for the main item.

![image](https://cloud.githubusercontent.com/assets/1986378/13984420/e8edf932-f0d4-11e5-8b09-c362bb9e2e23.png)

![image](https://cloud.githubusercontent.com/assets/1986378/13984751/f743873e-f0d6-11e5-9937-ca6dcc7e003d.png)