### PR TITLE
Fix Segment analytics

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 # build new base and app images
-docker build -t reactioncommerce/redoc:latest .
+docker build --build-arg NODE_VERSION=4.8.7 -t reactioncommerce/redoc:latest .
 
 # run the container and wait for it to boot
 docker-compose -f .circleci/docker-compose.yml up -d

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,11 @@ jobs:
 
     steps:
       - setup_remote_docker
-      - checkout
 
       # install OS dependencies
       - run: apk update && apk upgrade && apk add --no-cache bash git openssh py-pip && pip install docker-compose
+
+      - checkout
 
       # run build test
       - run: .circleci/build.sh

--- a/common/main.jsx
+++ b/common/main.jsx
@@ -7,7 +7,6 @@ import { default as ReactCookie } from "react-cookie";
 import { RedocAdmin } from "meteor/reactioncommerce:redoc-core/components/admin";
 import createHistory from "history/createBrowserHistory";
 
-const analytics = analytics || null;
 
 const AppRoutes = (
   <Route component={Layout} path="/">

--- a/common/main.jsx
+++ b/common/main.jsx
@@ -17,7 +17,7 @@ const AppRoutes = (
   </Route>
 );
 
-let clientOptions = {
+const clientOptions = {
   props: {
     onUpdate() {
       if (analytics) {
@@ -37,7 +37,7 @@ let clientOptions = {
 };
 
 function getBasename() {
-  let el = document.createElement("a");
+  const el = document.createElement("a");
   el.href = __meteor_runtime_config__.ROOT_URL; // eslint-disable-line camelcase
   if (el.pathname.substr(-1) !== "/") {
     return el.pathname + "/";
@@ -46,7 +46,7 @@ function getBasename() {
 }
 
 if (Meteor.isClient) {
-  let history = useRouterHistory(createHistory)({
+  const history = useRouterHistory(createHistory)({
     basename: getBasename()
   });
 


### PR DESCRIPTION
Fixes #90 

I don't really know how this started, but [this line](https://github.com/reactioncommerce/redoc/blob/master/common/main.jsx#L10) was causing `analytics` to always be undefined in that router context below it, so the `onUpdate` hook was never able to call it.  Hopping into the browser console and running `analytics.page()` worked every time, but the router never called it.  I removed that one line and now it works every time.  Old unmaintained Meteor packages FTW!

The CI change here is just pinning the older Node version because this project uses Meteor 1.5.

Build was successful and container tests passed.

https://circleci.com/gh/reactioncommerce/redoc/199

Once this is merged to master, it should get automatically deployed by Docker Cloud and our analytics should start working again.  Note that there is now a new site set up for `docs.reactioncommerce.com` in both Segment and GA. 